### PR TITLE
Fix for query and hash string consistency in url

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,7 +1,18 @@
+// Reference: https://stackoverflow.com/a/1714899
+var serialize = function(obj) {
+  var str = [];
+  for(var p in obj)
+    if (obj.hasOwnProperty(p)) {
+      str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
+    }
+  return str.join("&");
+}
+
 Wizard.registerRouter('iron:router', {
   go: function(name, stepId) {
     var p = {};
-    if( !!this.getParams(stepId).query && $.param(this.getParams(stepId).query) != "" ) p.query = $.param(this.getParams(stepId).query);
+    var queryString = serialize(this.getParams(stepId).query);
+    if( !!this.getParams(stepId).query && queryString != "" ) p.query = queryString;
     if( !!this.getParams(stepId).hash ) p.hash = this.getParams(stepId).hash;
     Router.go(name, this.getParams(stepId), p);
   },

--- a/client.js
+++ b/client.js
@@ -1,6 +1,9 @@
 Wizard.registerRouter('iron:router', {
   go: function(name, stepId) {
-    Router.go(name, this.getParams(stepId));
+    var p = {};
+    if( !!this.getParams(stepId).query && $.param(this.getParams(stepId).query) != "" ) p.query = $.param(this.getParams(stepId).query);
+    if( !!this.getParams(stepId).hash ) p.hash = this.getParams(stepId).hash;
+    Router.go(name, this.getParams(stepId), p);
   },
   getParams: function(stepId) {
     return Tracker.nonreactive(function() {


### PR DESCRIPTION
URL parameters do not persist (i.e. query parameter is lost) when form goes to next step or returns to previous step. This problem is fixed in this request.